### PR TITLE
feat: 将主页重构为社区化页面并增加帖子互动能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# rosebot1337.github.io is a test web
+# 星火社区 Demo
+
+## 模块说明
+- `login/`：登录与注册模块（前端页面）
+- `game/`：单页面小游戏模块（点击挑战 + 排行榜）
+- `backend/`：FastAPI 后端（认证 + 成绩提交 + 排行榜）
+
+## 启动后端（FastAPI）
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+
+## 启动前端静态页
+在仓库根目录执行：
+```bash
+python -m http.server 4173
+```
+然后访问：
+- http://127.0.0.1:4173/login/index.html
+- http://127.0.0.1:4173/game/index.html

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# FastAPI Backend
+
+## 安装
+```bash
+pip install -r requirements.txt
+```
+
+## 启动
+```bash
+uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+
+接口前缀：`/api`

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,144 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import hashlib
+import json
+import secrets
+from typing import Dict, Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+BASE_DIR = Path(__file__).resolve().parent
+DATA_FILE = BASE_DIR / "data.json"
+TOKEN_EXPIRE_HOURS = 24
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _load_data() -> Dict:
+    if not DATA_FILE.exists():
+        default = {
+            "users": {},
+            "tokens": {},
+            "scores": []
+        }
+        DATA_FILE.write_text(json.dumps(default, ensure_ascii=False, indent=2), encoding="utf-8")
+        return default
+    return json.loads(DATA_FILE.read_text(encoding="utf-8"))
+
+
+def _save_data(data: Dict) -> None:
+    DATA_FILE.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode("utf-8")).hexdigest()
+
+
+class RegisterRequest(BaseModel):
+    username: str = Field(min_length=3, max_length=20)
+    password: str = Field(min_length=6, max_length=64)
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class ScoreRequest(BaseModel):
+    token: str
+    score: int = Field(ge=0, le=999999)
+
+
+app = FastAPI(title="Community Game Backend", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/api/health")
+def health():
+    return {"ok": True, "time": _now().isoformat()}
+
+
+@app.post("/api/auth/register")
+def register(payload: RegisterRequest):
+    data = _load_data()
+    username = payload.username.strip()
+    if username in data["users"]:
+        raise HTTPException(status_code=409, detail="用户名已存在")
+
+    data["users"][username] = {
+        "password_hash": _hash_password(payload.password),
+        "created_at": _now().isoformat(),
+    }
+    _save_data(data)
+    return {"message": "注册成功"}
+
+
+@app.post("/api/auth/login")
+def login(payload: LoginRequest):
+    data = _load_data()
+    user = data["users"].get(payload.username)
+    if not user or user["password_hash"] != _hash_password(payload.password):
+        raise HTTPException(status_code=401, detail="用户名或密码错误")
+
+    token = secrets.token_urlsafe(24)
+    expires_at = (_now() + timedelta(hours=TOKEN_EXPIRE_HOURS)).isoformat()
+    data["tokens"][token] = {"username": payload.username, "expires_at": expires_at}
+    _save_data(data)
+    return {"token": token, "username": payload.username, "expires_at": expires_at}
+
+
+def _resolve_user_by_token(token: str) -> Optional[str]:
+    data = _load_data()
+    token_info = data["tokens"].get(token)
+    if not token_info:
+        return None
+
+    expires_at = datetime.fromisoformat(token_info["expires_at"])
+    if expires_at < _now():
+        data["tokens"].pop(token, None)
+        _save_data(data)
+        return None
+    return token_info["username"]
+
+
+@app.get("/api/auth/me")
+def me(token: str):
+    username = _resolve_user_by_token(token)
+    if not username:
+        raise HTTPException(status_code=401, detail="登录态无效")
+    return {"username": username}
+
+
+@app.post("/api/game/submit")
+def submit_score(payload: ScoreRequest):
+    username = _resolve_user_by_token(payload.token)
+    if not username:
+        raise HTTPException(status_code=401, detail="登录态无效，请重新登录")
+
+    data = _load_data()
+    data["scores"].append(
+        {
+            "username": username,
+            "score": payload.score,
+            "created_at": _now().isoformat(),
+        }
+    )
+    data["scores"] = sorted(data["scores"], key=lambda x: x["score"], reverse=True)[:20]
+    _save_data(data)
+    return {"message": "成绩已提交"}
+
+
+@app.get("/api/game/leaderboard")
+def leaderboard():
+    data = _load_data()
+    return {"items": data["scores"][:10]}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0

--- a/css/style.css
+++ b/css/style.css
@@ -1,681 +1,240 @@
-*{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;}
-ul,ol,dl,table,th,tr,td,input,textarea,li,a,div,span,em,i{margin: 0;padding: 0;	border: 0;}
-img {margin: 0;padding: 0;	border: 0;}
-li {list-style: none;}
-/*全局样式*/
-html,body {width: 100%;	margin: 0 auto;}
-/*= 清除浮动=*/
-.clear {clear: both;height: 0px;line-height: 0px;font-size: 0px;overflow: hidden;display: block;}
-.clearfix:after {content: "";display: block;height: 0px;clear: both;visibility: hidden;font-size: 0px;}
-:focus{outline:0}
-a, button, input[type="button"], input[type="submit"], input[type="reset"]{cursor:pointer}
-/* Hides from IE-mac \*/
-* html .clearfix {height: 0%;}
-/* End hide from IE-mac */
-* + html .clearfix {min-height: 0%;}
-/* 针对IE7 */
-* + html .clearfix {min-height: 0%;}
-.w100 {width: 100%;}
-.fl {float: left;}
-.fr {float: right;}
-/*原文件配置*/
-body {color: rgba(255, 255, 255, 0);background: #fa027600 ;font: 16px/30px 'Microsoft YaHei', arial, sans-serif;cursor: url('../images/icon_mouse.svg'), auto;}
-a {color: rgb(79, 139, 204);text-decoration: none;}
-a:hover {color: #e69f0b;cursor:url('../images/icon_mouse2.svg'), auto;}
-a {color: rgb(103, 34, 124);text-decoration: none;}
-a:hover {color: #e69f0b;}
-/*块级转化*/
-.di_in {display: inline-block;}
-.di_bl {display: block;}
-/*原文件配置  end*/
+:root {
+  --bg: #090c1a;
+  --panel: rgba(18, 24, 48, 0.86);
+  --panel-border: rgba(140, 180, 255, 0.28);
+  --primary: #6ca8ff;
+  --accent: #7af7d5;
+  --text: #eef4ff;
+  --muted: #a4b3d8;
+}
 
-/*纵向居中*/
-.v_middle {vertical-align: middle;}
-/*横向居中*/
-.te_c {text-align: center;}
-/*相对定位*/
-.p_r {position: relative;}
-/* 白色背景 */
-.bgfff {background: rgba(128, 230, 39, 0.832);}
-.flex {display: -webkit-box;display: -webkit-flex;display: -ms-flexbox;display: flex;}
-.flex-v {-webkit-box-orient: vertical;-webkit-flex-direction: column;-ms-flex-direction: column;flex-direction: column;}
-.flex-1 {-webkit-box-flex: 1;-webkit-flex: 1;-ms-flex: 1;flex: 1;}
-.flex-align-center {-webkit-box-align: center;-webkit-align-items: center;-ms-flex-align: center;align-items: center;}
-.flex-pack-center {-webkit-box-pack: center;-webkit-justify-content: center;-ms-flex-pack: center;justify-content: center;}
-.flex-pack-justify {-webkit-box-pack: justify;-webkit-justify-content: pace-between;-ms-flex-pack: justify;justify-content: space-between;}
-.flex-warp{flex-flow: wrap}
-.flex-column{flex-flow: column}
-.ellipsis{overflow: hidden;text-overflow: ellipsis;white-space: nowrap;}
-.transition{-webkit-transition: all .5s; -moz-transition: all .5s;-ms-transition: all .5s;-o-transition: all .5s;transition: all .5s}
-.img_hover{transition: all .3s;}
-.img_hover:hover{transform: scale(1.05,1.05);}
-/*全局样式 start*/
-.container{width: 100%;height: 100vh;color: #FFF;}
-.header{padding: 45px 140px;border-bottom: 1px #445fca dashed;}
-.header .user-info .portrait{width: 45px;height: 45px;border: 2px #FFF solid;overflow: hidden;border-radius: 50%;margin-right: 15px;}
-.header .user-info .portrait img{width: 100%;}
-.header .user-info .name{text-transform: uppercase;font-size: 26px;}
-.header .link{height: 44px;line-height: 44px;font-size: 21px;}
-.header .link li {width: 125px;border-radius: 22px;z-index: 2;}
-.header .link li a{color: #C2C2C2;width: 100%;}
-.header .link li.cur{}
-.header .link li.cur a{color: rgba(0, 148, 234, 0.625);} 
-.header .link a.cur{background-color: #FFF;color: #000;}
+* {
+  box-sizing: border-box;
+}
 
-.move-bg{position: absolute;background-color: #FFF;color: #000;left: 0;width: 125px;border-radius: 22px;height: 44px;display: none;top: 0;z-index: 1;}
-/*全局样式 end*/
-.warp{padding: 45px 140px;}
-.warp .txt{font-size: 20px;line-height: 1.5;margin-top: 45px;}
-.warp ul{margin-top: 20px;padding-bottom: 50px;}
-.warp li{border-radius: 10px;background: #202020;border: 1px solid #28292a;width: calc(20% - 2%);height: 180px;margin-right: 2%;margin-top: 40px;padding:30px 40px;overflow: hidden;}
-.warp li .icon{width: 54px;height: 54px;border: 1px solid #28292a;}
-.warp li .icon img{width: 54px;height: 54px;border-radius: 5px;}
-.warp li h3{margin-bottom: 0;font-weight: normal;font-size: 20px;color: #FFF;line-height: 1.5;margin-top: 10px;;}
-.warp li h3 a{color: #FFF;}
-.warp li p{margin: 0;font-size: 14px;color: #21e91b99;}
-.warp li:hover{margin-top: 10px;}
-.c1{color: #5400fa;}
-.c2{color: #008cff;}
+body {
+  margin: 0;
+  font-family: "PingFang SC", "Microsoft Yahei", sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top, #1c2a58 0%, var(--bg) 60%);
+  min-height: 100vh;
+}
 
-.content{padding: 45px 140px;height: calc(100vh - 136px);color: #FFF;}
-.content .en_box{position: absolute;left: 0;top: 0;height: 100%;border-right: 1px #262626 dashed;width: 22%;}
-.content .en{font-size: 112px;line-height: 1;text-transform: uppercase;transform:rotate(90deg);-ms-transform:rotate(90deg);-moz-transform:rotate(90deg);-webkit-transform:rotate(90deg);-o-transform:rotate(90deg);margin-bottom: 10vh;}
-.content .en span{color: #ea00fbc5;margin:0 15px;}
-.content .r_content{position: absolute;right: 0;top: 0;height: 100%;width: 78%;}
-.content .r_content .con{height: 26vh;}
-.content .r_content .con::after{content: '';position: absolute;left: -1vw;border-bottom: 1px #262626 dashed;right: 0;height: 1px;bottom: 0;}
-.content .r_content .name{font-size: 158px;width: 30vw;}
-.content .r_content .name .tips{font-size: 19px;position: absolute;left: 4px;right: 4px;bottom: -5px;z-index: 1;opacity: 0;}
-.content .r_content .name:hover .tips{opacity: 1;bottom: 5px;}
-.content .r_content .name .tips::after{content: '';position: absolute;left: 0;height: 70%;width: 1px;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .name .tips::before{content: '';position: absolute;right: 0;height: 70%;width: 1px;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .name .tips span::after{content: '';position: absolute;left: -12.4vw;height: 1px;width: 10.2vw;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .name .tips span::before{content: '';position: absolute;right: -12.4vw;height: 1px;width: 10.2vw;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .iphone{border-left: 1px #262626 dashed;width: 15vw;}
-.content .r_content .iphone img{max-width: 90%;}
-.content .r_content .web{border-left: 1px #262626 dashed;width: 15.1vw;}
-.content .r_content .web img{max-width: 90%;}
-.content .r_content .vr{border-left: 1px #262626 dashed;width: 17vw;}
-.content .r_content .vr img{max-width: 90%;}
+.background-glow {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 30%, rgba(122, 247, 213, 0.25), transparent 35%),
+              radial-gradient(circle at 80% 20%, rgba(108, 168, 255, 0.25), transparent 30%);
+}
 
-.content .r_content .con1{height: 35vh;}
-.content .r_content .con1::after{content: '';position: absolute;left: -1vw;border-bottom: 1px #262626 dashed;right: 0;height: 1px;bottom: 0;}
-.content .r_content .con1 .txt_box{width: 30vw;}
-.content .r_content .con1 .txt_box::after{content: '';position: absolute;right: 0;top: 0;bottom: -2vh;width: 1px;border-right: 1px #262626 dashed;}
-.content .r_content .con1 .txt_box .txt_con{width: 100%;height: 16.5vh;}
-.content .r_content .con1 .txt_box .txt_con::after{content: '';position: absolute;left: -1vw;border-bottom: 1px #262626 dashed;right: 0;height: 1px;bottom: 0;}
-.content .r_content .con1 .pic{width: 15vw;overflow: hidden;}
-.content .r_content .con1 .pic img{height: 100%;width: 100%;}
-.content .r_content .con1 .ui{font-size: 64px;border-right: 1px #262626 dashed;}
-.content .r_content .con1 .ui .tips{color: #5D24E4;font-size: 18px;position: absolute;right: -15px;bottom: 0;z-index: 1;opacity: 0;top: 0;width: 30px;}
-.content .r_content .con1 .ui:hover .tips{opacity: 1;right: 5px;}
-.content .r_content .con1 .ui .tips span{transform:rotate(90deg);-ms-transform:rotate(90deg);-moz-transform:rotate(90deg);-webkit-transform:rotate(90deg);-o-transform:rotate(90deg);position: absolute;}
-.content .r_content .con1 .ui .tips::after{content: '';position: absolute;left: 50%;height: 1px;width: 60%;background-color: #FFF;transform: translateX(-50%);top: 0;}
-.content .r_content .con1 .ui .tips::before{content: '';position: absolute;left: 50%;height: 1px;width: 60%;background-color: #FFF;transform: translateX(-50%);bottom: 0;}
-.content .r_content .con1 .ui .tips span::after{content: '';position: absolute;left: -2.2vw;height: 1px;width: 2vw;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .con1 .ui .tips span::before{content: '';position: absolute;right: -2.2vw;height: 1px;width: 2vw;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .con1 .wx{width: 11vw;}
-.content .r_content .con1 .wx img{width: 4vw;}
-.content .r_content .con1 .wx .tips{font-size: 18px;position: absolute;left: 4px;right: 4px;bottom: -10px;z-index: 1;opacity: 0;}
-.content .r_content .con1 .wx:hover .tips{opacity: 1;bottom: 5px;}
-.content .r_content .con1 .wx .tips::after{content: '';position: absolute;left: 0;height: 60%;width: 1px;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .con1 .wx .tips::before{content: '';position: absolute;right: 0;height: 60%;width: 1px;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .con1 .wx .tips span::after{content: '';position: absolute;left: -3.8vw;height: 1px;width: 3vw;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .con1 .wx .tips span::before{content: '';position: absolute;right: -3.8vw;height: 1px;width:3vw;background-color: #FFF;transform: translateY(-50%);top: 50%;}
-.content .r_content .con1 .text{line-height: 1.5;font-size: 20px;padding: 3vh 3vw;}
-.content .r_content .con1 .text span{padding-top: 0.8vh;}
-.content .r_content .con1 .text::after{content: '';position: absolute;left: 1.2vw;right: 1.2vw;top: 2.8vh;bottom: 2vh;border-top: 1px #ff9850 dashed;border-bottom: 1px #ff9850 dashed;opacity: 0;-webkit-transition: all .5s; -moz-transition: all .5s;-ms-transition: all .5s;-o-transition: all .5s;transition: all .5s}
-.content .r_content .con1 .text::before{content: '';position: absolute;left: 2vw;right: 2vw;top: 1.3vh;bottom: 0.5vh;border-left: 1px #ff9850 dashed;border-right: 1px #ff9850 dashed;opacity: 0;-webkit-transition: all .5s; -moz-transition: all .5s;-ms-transition: all .5s;-o-transition: all .5s;transition: all .5s}
-.content .r_content .con1 .text:hover::after,.content .r_content .con1 .text:hover::before{opacity: 1;-webkit-transition: all .5s; -moz-transition: all .5s;-ms-transition: all .5s;-o-transition: all .5s;transition: all .5s}
-.content .r_content .con1 .focus{width: 15vw;line-height: 1.5;padding: 1.6vh 0 0 1.5vw;font-size: 18px;}
-.content .r_content .con1 .focus::after{content: '';position: absolute;left: 0;top: 0;bottom: -2vh;width: 1px;border-right: 1px #262626 dashed;}
-.content .r_content .con1 .focus .txt{display: none;}
-
-
-
-/* 底部 */
-.content .r_content .tool_content{padding: 2vh 2vw;height: 18vh;}
-.content .r_content .tool_content::after{content: '';position: absolute;left: -1vw;border-bottom: 1px #262626 dashed;right: 0;height: 1px;bottom: 0;}
-.content .r_content .tool_content .text{position: absolute;right: 4vw;bottom: 10px;text-align: right;font-size: 20px;}
-.content .r_content .tool_content .text p{margin: 0;font-size: 18px;}
-.content .r_content .tool_content .sns .wx .erwma{width: 64px;height: 64px;position: absolute;bottom: 24px;left: 50%;transform: translateX(-50%);opacity: 0;}
-.content .r_content .tool_content .sns .wx .erwma img{width: 100%;}
-.content .r_content .tool_content .sns .wx:hover .erwma{opacity: 1;bottom: 34px;}
-.content .r_content .tool_content .sns .figma{background: url(../images/icon_figma.svg)no-repeat center;background-size: 100%;margin-left: 2vw;}
-.content .r_content .tool_content .sns .figma:hover{background: url(../images/icon_figma_hover.svg)no-repeat center;}
-.content .r_content .con1 .works .lock input {background: #1e1ede url(../images/lock.svg)no-repeat 0.8vw center;padding-left: 2.5vw;width: 100%;height: 40px;background-size: 22px;color: #FFF;}
-.content .r_content .tool_content .sns .mail span{width: 100%;height: 24px;}
-.content .r_content .tool_content .sns .mail .copytxt{opacity: 0;position: absolute;left: 50%;transform: translateX(-50%);background-color: #FFF;color: #000;border-radius: 5px;padding: 2px 0px;bottom: 30px;width: 60px;font-size: 14px;}
-.content .r_content .tool_content .sns .mail input{opacity: 0;width: 5px;height: 5px;position: absolute;left: 0;z-index: 0;top: 0}
-
-/*icon*/
-.flex-center {
-  width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -ms-flex-align: center;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 6vw;
+  background: rgba(5, 10, 25, 0.75);
+  border-bottom: 1px solid var(--panel-border);
+  backdrop-filter: blur(8px);
+}
+
+.logo {
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+nav {
+  display: flex;
+  gap: 20px;
+}
+
+nav a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.layout {
+  width: min(1200px, 92vw);
+  margin: 28px auto 40px;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 18px;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  padding: 18px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.26);
+}
+
+.hero,
+.composer,
+.feed {
+  grid-column: 1;
+}
+
+.hero h1 {
+  margin: 0 0 6px;
+  font-size: 1.8rem;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.hero-stats {
+  margin-top: 16px;
+  display: flex;
+  gap: 14px;
+}
+
+.hero-stats div {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.hero-stats strong {
+  display: block;
+  font-size: 1.15rem;
+}
+
+.hero-stats span {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.composer form {
+  display: grid;
+  gap: 10px;
+}
+
+input,
+textarea,
+select,
+button {
+  font: inherit;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  border: 1px solid rgba(168, 188, 235, 0.38);
+  background: rgba(3, 8, 21, 0.9);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  cursor: pointer;
+}
+
+.btn-primary {
+  justify-self: start;
+  background: linear-gradient(120deg, var(--primary), #7a84ff);
+  color: #fff;
+}
+
+.btn-secondary {
+  background: rgba(122, 247, 213, 0.18);
+  color: var(--accent);
+  border: 1px solid rgba(122, 247, 213, 0.4);
+}
+
+.feed-header {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
 }
 
-.icon-3d {
-  padding: 10px;
-  -webkit-animation: icon3d 200ms 10;
-  animation: icon3d 200ms 10;
-  color: #01a4f0;
-}
-.icon-3d:hover {
-  -webkit-animation: icon3d 200ms infinite;
-  animation: icon3d 200ms infinite;
-}
-.fa-siz {
-    font-size: 2em;
-    margin-left: 1vw;
-    
-}
-@keyframes icon3d {
-  0% {
-    text-shadow: 5px 4px #79e28c, -5px -6px #79e28c;
-  }
-  25% {
-    text-shadow: -5px -6px #79e28c, 5px 4px #79e28c;
-  }
-  50% {
-    text-shadow: 5px -4px #79e28c, -8px 4px #79e28c;
-  }
-  75% {
-    text-shadow: -8px -4px #79e28c, -5px -4px #79e28c;
-  }
-  100% {
-    text-shadow: -5px 0 #79e28c, 5px -4px #79e28c;
-  }
-}
-/*MacBook Air*/
-.macbook {
-  width: 150px;
-  height: 96px;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin: -75px 0 0 -48px;
-  perspective: 500px;
-}
-.shadow {
-  position: absolute;
-  width: 60px;
-  height: 0px;
-  left: 40px;
-  top: 160px;
-  transform: rotateX(80deg) rotateY(0deg) rotateZ(0deg);
-  box-shadow: 0 0 60px 40px rgba(0,0,0,0.3);
-  animation: shadow infinite 7s ease;
-}
-.inner {
-  z-index: 20;
-  position: absolute;
-  width: 150px;
-  height: 96px;
-  left: 0;
-  top: 0;
-  transform-style: preserve-3d;
-  transform:rotateX(-20deg) rotateY(0deg) rotateZ(0deg);
-  animation: rotate infinite 7s ease;
-}
-.screen {
-  width: 150px;
-  height: 96px;
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  border-radius: 7px;
-  background: #ddd;
-  transform-style: preserve-3d;
-  transform-origin: 50% 93px;
-  transform: rotateX(0deg) rotateY(0deg) rotateZ(0deg);
-  animation: lid-screen infinite 7s ease;
-  background-image: linear-gradient(45deg, rgba(0,0,0,0.34) 0%,rgba(0,0,0,0) 100%);
-  background-position: left bottom;
-  background-size: 300px 300px;
-  box-shadow: inset 0 3px 7px rgba(255,255,255,0.5);
-}
-.screen .logo {
-  position: absolute;
-  width: 20px;
-  height: 24px;
-  left: 50%;
-  top: 50%;
-  margin: -12px 0 0 -10px;
-  transform: rotateY(180deg) translateZ(0.1px);
-}
-.screen .face-one {
-  width: 150px;
-  height: 96px;
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  border-radius: 7px;
-  background: #d3d3d3;
-  transform: translateZ(2px);
-  background-image: linear-gradient(45deg,rgba(0,0,0,0.24) 0%,rgba(0,0,0,0) 100%);
-}
-.screen .face-one .camera {
-  width: 3px;
-  height: 3px;
-  border-radius: 100%;
-  background: #000;
-  position: absolute;
-  left: 50%;
-  top: 4px;
-  margin-left: -1.5px;
-}
-.screen .face-one .display {
-  width: 130px;
-  height: 74px;
-  margin: 10px;
-  background: url("") no-repeat center center #000;
-  background-size: 100% 100%;
-  border-radius: 1px;
-  position: relative;
-  box-shadow: inset 0 0 2px rgba(0,0,0,1);
-}
-.screen .face-one .display .shade {
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 130px;
-  height: 74px;
-  background: linear-gradient(-135deg, rgba(255,255,255,0) 0%,rgba(255,255,255,0.1) 47%,rgba(255,255,255,0) 48%);
-  animation: screen-shade infinite 7s ease;
-  background-size: 300px 200px;
-  background-position: 0px 0px;
-}
-.screen .face-one span {
-  position: absolute;
-  top: 85px;
-  left: 57px;
-  font-size: 6px;
-  color: #666
+.post-list {
+  margin-top: 14px;
+  display: grid;
+  gap: 12px;
 }
 
-.body {
-  width: 150px;
-  height: 96px;
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  border-radius: 7px;
-  background: #cbcbcb;
-  transform-style: preserve-3d;
-  transform-origin: 50% bottom;
-  transform: rotateX(-90deg);
-  animation: lid-body infinite 7s ease;
-  background-image: linear-gradient(45deg, rgba(0,0,0,0.24) 0%,rgba(0,0,0,0) 100%);
-}
-.body .face-one {
-  width: 150px;
-  height: 96px;
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  border-radius: 7px;
-  transform-style: preserve-3d;
-  background: #dfdfdf;
-  animation: lid-keyboard-area infinite 7s ease;
-  transform: translateZ(-2px);
-  background-image: linear-gradient(30deg, rgba(0,0,0,0.24) 0%,rgba(0,0,0,0) 100%);
-}
-.body .touchpad {
-  width: 40px;
-  height: 31px;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  border-radius: 4px;
-  margin: -44px 0 0 -18px;
-  background: #cdcdcd;
-  background-image: linear-gradient(30deg, rgba(0,0,0,0.24) 0%,rgba(0,0,0,0) 100%);
-  box-shadow: inset 0 0 3px #888;
-}
-.body .keyboard {
-width: 130px;
-height: 45px;
-position: absolute;
-left: 7px;
-top: 41px;
-border-radius: 4px;
-transform-style: preserve-3d;
-background: #cdcdcd;
-background-image: linear-gradient(30deg, rgba(0,0,0,0.24) 0%,rgba(0,0,0,0) 100%);
-box-shadow: inset 0 0 3px #777;
-padding: 0 0 0 2px;
-}
-.keyboard .key {
-  width: 6px;
-  height: 6px;
-  background: #444;
-  float: left;
-  margin: 1px;
-  transform: translateZ(-2px);
-  border-radius: 2px;
-  box-shadow: 0 -2px 0 #222;
-  animation: keys infinite 7s ease;
-}
-.key.space {
-  width: 45px;
-}
-.key.f {
-  height: 3px;
-}
-.body .pad {
-  width: 5px;
-  height: 5px;
-  background: #333;
-  border-radius: 100%;
-  position: absolute;
-}
-.pad.one {
-  left: 20px;
-  top: 20px;
-}
-.pad.two {
-  right: 20px;
-  top: 20px;
-}
-.pad.three {
-  right: 20px;
-  bottom: 20px;
-}
-.pad.four {
-  left: 20px;
-  bottom: 20px;
+.post-item {
+  border: 1px solid rgba(168, 188, 235, 0.26);
+  border-radius: 12px;
+  padding: 14px;
+  background: rgba(0, 0, 0, 0.18);
 }
 
-@keyframes rotate {
-  0% {
-    transform: rotateX(-20deg) rotateY(0deg) rotateZ(0deg);
-  }
-  5% {
-    transform: rotateX(-20deg) rotateY(-20deg) rotateZ(0deg);
-  }
-  20% {
-    transform: rotateX(30deg) rotateY(200deg) rotateZ(0deg);
-  }
-  25% {
-    transform: rotateX(-60deg) rotateY(150deg) rotateZ(0deg);
-  }
-  60% {
-    transform: rotateX(-20deg) rotateY(130deg) rotateZ(0deg);
-  }
-  65% {
-    transform: rotateX(-20deg) rotateY(120deg) rotateZ(0deg);
-  }
-  80% {
-    transform: rotateX(-20deg) rotateY(375deg) rotateZ(0deg);
-  }
-  85% {
-    transform: rotateX(-20deg) rotateY(357deg) rotateZ(0deg);
-  }
-  87% {
-    transform: rotateX(-20deg) rotateY(360deg) rotateZ(0deg);
-  }
-  100% {
-    transform: rotateX(-20deg) rotateY(360deg) rotateZ(0deg);
-  }
+.post-item header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
 }
 
-@keyframes lid-screen {
-  0% {
-    transform: rotateX(0deg);
-    background-position: left bottom;
-  }
-  5% {
-    transform: rotateX(50deg);
-    background-position: left bottom;
-  }
-  20% {
-    transform: rotateX(-90deg);
-    background-position: -150px top;
-  }
-  25% {
-    transform: rotateX(15deg);
-    background-position: left bottom;
-  }
-  30% {
-    transform: rotateX(-5deg);
-    background-position: right top;
-  }
-  38% {
-    transform: rotateX(5deg);
-    background-position: right top;
-  }
-  48% {
-    transform: rotateX(0deg);
-    background-position: right top;
-  }
-  90% {
-    transform: rotateX(0deg);
-    background-position: right top;
-  }
-  100% {
-    transform: rotateX(0deg);
-    background-position: right center;
-  }
+.post-title {
+  margin: 0;
 }
 
-@keyframes lid-body {
-  0% {
-    transform: rotateX(-90deg);
-    
-  }
-  50% {
-    transform: rotateX(-90deg);
-    
-  }
-  100% {
-    transform: rotateX(-90deg);
-    
-  }
+.post-meta,
+.post-content,
+.post-replies,
+.reply-list {
+  color: var(--muted);
 }
 
-@keyframes lid-keyboard-area {
-  0% {
-     background-color: #dfdfdf;
-  }
-  50% {
-    background-color: #bbb;
-  }
-  100% {
-    background-color: #dfdfdf;
-  }
-}
-@keyframes screen-shade {
-  0% {
-    background-position: -20px 0px;
-  }
-  5% {
-    background-position: -40px 0px;
-  }
-  20% {
-    background-position: 200px 0;
-  }
-  50% {
-    background-position: -200px 0;
-  }
-  80% {
-    background-position: 0px 0px;
-  }
-  85% {
-    background-position: -30px 0;
-  }
-  90% {
-    background-position: -20px 0;
-  }
-  100% {
-    background-position: -20px 0px;
-  }
-}
-@keyframes keys {
-  0% {
-    box-shadow: 0 -2px 0 #222;
-  }
-  5% {
-    box-shadow: 1 -1px 0 #222;
-  }
-  20% {
-    box-shadow: -1px 1px 0 #222;
-  }
-  25% {
-    box-shadow: -1px 1px 0 #222;
-  }
-  60% {
-    box-shadow: -1px 1px 0 #222;
-  }
-  80% {
-    box-shadow: 0 -2px 0 #222;
-  }
-  85% {
-    box-shadow: 0 -2px 0 #222;
-  }
-  87% {
-    box-shadow: 0 -2px 0 #222;
-  }
-  100% {
-    box-shadow: 0 -2px 0 #222;
-  }
-}
-@keyframes shadow {
-  0% {
-    transform: rotateX(80deg) rotateY(0deg) rotateZ(0deg);
-    box-shadow: 0 0 60px 40px rgba(0,0,0,0.3);
-  }
-  5% {
-    transform: rotateX(80deg) rotateY(10deg) rotateZ(0deg);
-    box-shadow: 0 0 60px 40px rgba(0,0,0,0.3);
-  }
-  20% {
-    transform: rotateX(30deg) rotateY(-20deg) rotateZ(-20deg);
-    box-shadow: 0 0 50px 30px rgba(0,0,0,0.3);
-  }
-  25% {
-    transform: rotateX(80deg) rotateY(-20deg) rotateZ(50deg);
-    box-shadow: 0 0 35px 15px rgba(0,0,0,0.1);
-  }
-  60% {
-    transform: rotateX(80deg) rotateY(0deg) rotateZ(-50deg) translateX(30px);
-    box-shadow: 0 0 60px 40px rgba(0,0,0,0.3);
-  }
-  100% {
-    box-shadow: 0 0 60px 40px rgba(0,0,0,0.3);
-  }
-}
-/*Music*/
-.holder{
-  color: #60b044;
-}
-/*翻页渲染*/
-#background {
-    z-index: -1;
-    position: fixed;
-    left: 0;
-	width: 100%;
-	height: 100%;
-}
-@media (max-width: 1921px) {
-	/*修改1441以下、小屏显示器*/
-	.header{padding: 35px 90px 35px 105px;}
-	.warp{padding: 0px 105px}
-	.content{padding: 0px 105px;height: calc(100vh - 116px);}
-	.warp li{height: 160px;padding:20px 30px;margin-top: 30px;}
-	.content .r_content .name{font-size: 138px;}
-	.content .r_content .con1 .ui{font-size: 54px;}
-	.content .r_content .con1 .text{font-size: 18px;}
-	.content .r_content .con1 .works .submit{font-size: 22px;}
-}
-video{
-  position: fixed;
-  right:0;
-  bottom: 0;
-  min-width: 100%;
-  min-height: 100%;
-  width: auto;
-  height: auto;
-  z-index: -9999;
-  /*灰色调*/
-  /*-webkit-filter:grayscale(100%)*/
-
-}
-@media (max-width: 1681px) {
-	/*修改1441以下、小屏显示器*/
-	.header{padding: 30px 70px 25px 90px;}
-	.warp{padding: 0px 90px}
-	.content{padding: 0px 90px;height: calc(100vh - 106px);}
-	.content .en{font-size: 100px;}
-	.content .r_content .name{font-size: 128px;}
-	.content .r_content .con1 .ui{font-size: 42px;}
-	.content .r_content .con1 .text,.content .r_content .con1 .works .txt{font-size: 16px;}
-	.content .r_content .con1 .works .submit{font-size: 20px;}
-	.content .r_content .tool_content .text{font-size: 18px;}
-	.content .r_content .tool_content .text p{font-size: 16px;}
-	
+.reply-form {
+  margin-top: 10px;
 }
 
-@media (max-width: 1441px) {
-	/*修改1441以下、小屏显示器*/
-	.header{padding: 25px 65px 25px 75px;}
-	.header .user-info .portrait{height: 34px;width: 34px;}
-	.header .user-info .name{font-size: 20px;}
-	.header .link{font-size: 16px;height: 34px;line-height: 34px;}
-	.move-bg{height: 34px;}
-	.warp{padding: 0px 75px}
-	.content{padding: 0px 75px;height: calc(100vh - 96px);}
-	.warp li{width: calc(25% - 2%);margin-top: 20px;}
-	.content .en_box{width: 20%;}
-	.content .r_content{width: 80%;}
-	.content .en{font-size: 90px;}
-	.content .r_content .name{font-size: 118px;}
-	.content .r_content .con1 .ui .tips,.content .r_content .con1 .wx .tips,.content .r_content .name .tips{font-size: 16px;}
-	.content .r_content .con1 .focus{font-size: 16px;}
-	.content .r_content .con1 .works .txt{font-size: 14px;}
-	.content .r_content .con1 .works .submit{font-size: 16px;}
-	.content .r_content .tool_content .text{font-size: 16px;}
-	.content .r_content .tool_content .text p{font-size: 14px;}
-	.content .r_content .name .tips span::after,.content .r_content .name .tips span::before{width: 12vw;}
-	.content .r_content .name .tips span::after{left: -13vw;}
-	.content .r_content .name .tips span::before{right: -13vw;}
-	.content .r_content .vr{width: 17vw;}
-	.content .r_content .con1 .works{width: 16vw;}
+.reply-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
 }
 
-
-@media (max-width: 1367px) {
-	/*修改1441以下、小屏显示器*/
-	.header{padding: 20px 40px 20px 70px;}
-	.warp{padding: 0px 70px}
-	.content{padding: 0px 70px;height: calc(100vh - 86px);}
-	.content .en{font-size: 80px;}
-	.content .r_content .name{font-size: 88px;}
-	.content .r_content .con1 .ui .tips,.content .r_content .con1 .wx .tips,.content .r_content .name .tips{font-size: 14px;}
-	.content .r_content .con1 .focus{font-size: 14px;}
-	.content .r_content .vr{width: 18.5vw;}
-	.content .r_content .con1 .works{width: 16.5vw;}
+.sidebar {
+  grid-column: 2;
+  display: grid;
+  gap: 18px;
+  align-content: start;
 }
 
-@media (max-width: 1281px) {
-	/*修改1441以下、小屏显示器*/
-	.header{padding: 20px 65px;}
-	.warp{padding: 0px 65px}
-	.content{padding: 0px 65px;height: calc(100vh - 86px);}
-	.content .r_content .name{font-size: 98px;}
-	.content .r_content .con1 .text{font-size: 14px;}
-	.content .r_content .name .tips span::after,.content .r_content .name .tips span::before{width: 12vw;}
-	.content .r_content .name .tips span::after{left: -12.8vw;}
-	.content .r_content .name .tips span::before{right: -12.8vw;}
-	
+.topic-list,
+.event-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.event-list strong {
+  color: var(--text);
+  display: block;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .hero,
+  .composer,
+  .feed,
+  .sidebar {
+    grid-column: 1;
+  }
+
+  .topbar {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -24,8 +24,8 @@ body {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 20% 30%, rgba(122, 247, 213, 0.25), transparent 35%),
-              radial-gradient(circle at 80% 20%, rgba(108, 168, 255, 0.25), transparent 30%);
+  background: radial-gradient(circle at 20% 30%, rgba(122, 247, 213, 0.22), transparent 35%),
+    radial-gradient(circle at 80% 20%, rgba(108, 168, 255, 0.22), transparent 30%);
 }
 
 .topbar {
@@ -35,8 +35,9 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 6vw;
-  background: rgba(5, 10, 25, 0.75);
+  gap: 16px;
+  padding: 14px clamp(16px, 6vw, 72px);
+  background: rgba(5, 10, 25, 0.78);
   border-bottom: 1px solid var(--panel-border);
   backdrop-filter: blur(8px);
 }
@@ -45,11 +46,13 @@ body {
   font-size: 1.2rem;
   font-weight: 700;
   letter-spacing: 1px;
+  white-space: nowrap;
 }
 
 nav {
   display: flex;
-  gap: 20px;
+  flex-wrap: wrap;
+  gap: 16px;
 }
 
 nav a {
@@ -61,8 +64,23 @@ nav a {
   width: min(1200px, 92vw);
   margin: 28px auto 40px;
   display: grid;
-  grid-template-columns: 2fr 1fr;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
   gap: 18px;
+  align-items: start;
+}
+
+.main-column {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
+.sidebar {
+  display: grid;
+  gap: 18px;
+  align-content: start;
+  position: sticky;
+  top: 86px;
 }
 
 .card {
@@ -73,26 +91,28 @@ nav a {
   box-shadow: 0 12px 30px rgba(0, 0, 0, 0.26);
 }
 
-.hero,
-.composer,
-.feed {
-  grid-column: 1;
+h1,
+h2,
+h3,
+h4,
+p {
+  margin: 0;
 }
 
 .hero h1 {
-  margin: 0 0 6px;
-  font-size: 1.8rem;
+  font-size: clamp(1.35rem, 2.4vw, 1.9rem);
+  margin-bottom: 8px;
 }
 
 .hero p {
-  margin: 0;
   color: var(--muted);
 }
 
 .hero-stats {
   margin-top: 16px;
-  display: flex;
-  gap: 14px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
 }
 
 .hero-stats div {
@@ -134,6 +154,11 @@ select {
   padding: 10px 12px;
 }
 
+textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
 button {
   border: none;
   border-radius: 999px;
@@ -157,6 +182,11 @@ button {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
+}
+
+.feed-header select {
+  width: 132px;
 }
 
 .post-list {
@@ -175,11 +205,12 @@ button {
 .post-item header {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   gap: 8px;
 }
 
 .post-title {
-  margin: 0;
+  margin-bottom: 3px;
 }
 
 .post-meta,
@@ -187,6 +218,11 @@ button {
 .post-replies,
 .reply-list {
   color: var(--muted);
+}
+
+.post-content {
+  margin-top: 10px;
+  line-height: 1.6;
 }
 
 .reply-form {
@@ -198,13 +234,6 @@ button {
   padding-left: 18px;
   display: grid;
   gap: 6px;
-}
-
-.sidebar {
-  grid-column: 2;
-  display: grid;
-  gap: 18px;
-  align-content: start;
 }
 
 .topic-list,
@@ -221,20 +250,31 @@ button {
   display: block;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 980px) {
   .layout {
     grid-template-columns: 1fr;
   }
 
-  .hero,
-  .composer,
-  .feed,
   .sidebar {
-    grid-column: 1;
+    position: static;
   }
+}
 
+@media (max-width: 640px) {
   .topbar {
     flex-wrap: wrap;
-    gap: 10px;
+  }
+
+  .hero-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .feed-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .feed-header select {
+    width: 100%;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -250,6 +250,26 @@ button {
   display: block;
 }
 
+
+.quick-links a {
+  color: var(--accent);
+}
+
+.quick-links p {
+  margin-top: 10px;
+  color: var(--muted);
+}
+
+.quick-links code {
+  display: inline-block;
+  margin-top: 6px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  color: #d9e6ff;
+  word-break: break-all;
+}
+
 @media (max-width: 980px) {
   .layout {
     grid-template-columns: 1fr;

--- a/game/app.js
+++ b/game/app.js
@@ -1,0 +1,97 @@
+const TOKEN_KEY = "spark_token";
+const USER_KEY = "spark_user";
+
+const apiBaseInput = document.querySelector("#apiBase");
+const userNameEl = document.querySelector("#userName");
+const timeLeftEl = document.querySelector("#timeLeft");
+const scoreEl = document.querySelector("#score");
+const statusEl = document.querySelector("#status");
+const leaderboardEl = document.querySelector("#leaderboard");
+const tapBtn = document.querySelector("#tapBtn");
+
+let score = 0;
+let timeLeft = 30;
+let timer = null;
+
+function showStatus(text, ok = true) {
+  statusEl.textContent = text;
+  statusEl.style.color = ok ? "#7af7d5" : "#ff8f8f";
+}
+
+function getSession() {
+  return {
+    token: localStorage.getItem(TOKEN_KEY),
+    username: localStorage.getItem(USER_KEY)
+  };
+}
+
+async function fetchLeaderboard() {
+  const base = apiBaseInput.value.trim().replace(/\/$/, "");
+  const res = await fetch(`${base}/api/game/leaderboard`);
+  const data = await res.json();
+  leaderboardEl.innerHTML = "";
+  data.items.forEach((item, idx) => {
+    const li = document.createElement("li");
+    li.textContent = `${idx + 1}. ${item.username} - ${item.score} 分`;
+    leaderboardEl.appendChild(li);
+  });
+  if (!data.items.length) {
+    leaderboardEl.innerHTML = "<li>暂无成绩</li>";
+  }
+}
+
+function startGame() {
+  score = 0;
+  timeLeft = 30;
+  scoreEl.textContent = String(score);
+  timeLeftEl.textContent = String(timeLeft);
+  tapBtn.disabled = false;
+
+  clearInterval(timer);
+  timer = setInterval(() => {
+    timeLeft -= 1;
+    timeLeftEl.textContent = String(timeLeft);
+    if (timeLeft <= 0) {
+      clearInterval(timer);
+      tapBtn.disabled = true;
+      showStatus(`游戏结束！你的分数：${score}`);
+    }
+  }, 1000);
+}
+
+function tap() {
+  if (timeLeft <= 0) return;
+  score += 1;
+  scoreEl.textContent = String(score);
+}
+
+async function submitScore() {
+  const session = getSession();
+  if (!session.token || !session.username) {
+    showStatus("请先在登录模块登录", false);
+    return;
+  }
+
+  const base = apiBaseInput.value.trim().replace(/\/$/, "");
+  const res = await fetch(`${base}/api/game/submit`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: session.token, score })
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    showStatus(data.detail || "提交失败", false);
+    return;
+  }
+  showStatus("提交成功，排行榜已刷新");
+  await fetchLeaderboard();
+}
+
+document.querySelector("#startBtn").addEventListener("click", startGame);
+tapBtn.addEventListener("click", tap);
+document.querySelector("#submitBtn").addEventListener("click", submitScore);
+document.querySelector("#refreshBtn").addEventListener("click", fetchLeaderboard);
+
+const session = getSession();
+if (session.username) userNameEl.textContent = session.username;
+fetchLeaderboard();

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>游戏模块 - 星火社区</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="wrap">
+    <section class="card">
+      <h1>单页面小游戏：30 秒点击挑战</h1>
+      <p class="muted">登录后提交成绩到 FastAPI 排行榜。</p>
+
+      <label>后端地址</label>
+      <input id="apiBase" value="http://127.0.0.1:8000" />
+
+      <div class="panel">
+        <div>玩家：<strong id="userName">未登录</strong></div>
+        <div>倒计时：<strong id="timeLeft">30</strong>s</div>
+        <div>当前分数：<strong id="score">0</strong></div>
+      </div>
+
+      <div class="actions">
+        <button id="startBtn">开始游戏</button>
+        <button id="tapBtn" disabled>点击得分</button>
+        <button id="submitBtn">提交成绩</button>
+      </div>
+      <p id="status" class="status"></p>
+      <a href="../login/index.html">← 返回登录模块</a>
+    </section>
+
+    <section class="card">
+      <h2>排行榜 TOP10</h2>
+      <button id="refreshBtn">刷新排行榜</button>
+      <ol id="leaderboard"></ol>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/game/style.css
+++ b/game/style.css
@@ -1,0 +1,80 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: #0d1328;
+  color: #e8f0ff;
+}
+
+.wrap {
+  width: min(980px, 92vw);
+  margin: 24px auto;
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 16px;
+}
+
+.card {
+  background: #151e3f;
+  border: 1px solid #324a8b;
+  border-radius: 14px;
+  padding: 20px;
+}
+
+h1, h2, p { margin: 0 0 10px; }
+label { display:block; margin: 10px 0 6px; }
+input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid #4c67b2;
+  background: #0d142d;
+  color: #fff;
+}
+
+.panel {
+  margin: 14px 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.panel > div {
+  background: #0a1024;
+  border: 1px solid #324a8b;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  margin: 12px 0;
+  flex-wrap: wrap;
+}
+
+button {
+  padding: 10px 14px;
+  border: none;
+  border-radius: 10px;
+  background: linear-gradient(120deg, #6ca8ff, #7a84ff);
+  color: #fff;
+  cursor: pointer;
+}
+
+button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.status { min-height: 20px; color: #7af7d5; }
+.muted { color: #9fb1d8; }
+#leaderboard { margin-top: 12px; }
+#leaderboard li { margin-bottom: 6px; color: #d6e3ff; }
+a { color: #7af7d5; }
+
+@media (max-width: 860px) {
+  .wrap { grid-template-columns: 1fr; }
+  .panel { grid-template-columns: 1fr; }
+}

--- a/index.html
+++ b/index.html
@@ -1,434 +1,89 @@
 <!DOCTYPE html>
-
 <html lang="zh-CN">
 <head>
-<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>melanchoy</title>  
-<!--页面核心样式-->
-<video id="v1" autoplay muted loop style="width: 100%">
-    <source  src="images/video2.mp4">
-</video>
-<link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css'>
-<link rel="stylesheet" type="text/css" href="css/style.css"/>
-<!--页面核心JS-->
-<script type="text/javascript" src="js/uaredirect.js"></script>
-<script type="text/javascript">browserRedirect("/m");</script>
-<script src="https://libs.baidu.com/jquery/1.10.2/jquery.min.js"></script>
-	
-<script type="text/javascript" src="js/respond.min.js"></script>
-	
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>星火社区</title>
+  <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
-<div class="container slideTxtBox">
-    <div class="header flex flex-pack-justify flex-align-center">
-    <div class="user-info flex flex-align-center">
-        <div class="portrait"><img src="images/PEBIX7ME5KZF44CREQ5F3OJ.gif" ></div>
-        <div class="name PangMenZhengDao">all we need is love</div><!--左上角 Logo+站名-->
-    </div>
-    <div class="link te_c p_r hd">
-		<ul class="flex flex-align-center">
-		</ul>
-		<div class="move-bg"></div><!--右上方 部件-->
-	</div>
-	</div>
+  <div class="background-glow"></div>
+  <header class="topbar">
+    <div class="logo">星火社区</div>
+    <nav>
+      <a href="#feed">动态</a>
+      <a href="#topics">话题</a>
+      <a href="#events">活动</a>
+    </nav>
+    <button id="joinBtn" class="btn-secondary">加入社区</button>
+  </header>
 
-<!--页面内容-->	
-<div class="bd">
-<!--左侧小部件-MacBook Air-->
-<div class="content p_r">
-	<div class="en_box flex flex-align-center flex-pack-center">
-	<div class="macbook">
-  <div class="inner">
-    <div class="screen">
-      <div class="face-one">
-        <div class="camera"></div>
-        <div class="display">
-          <div class="shade"></div>
-        </div>
+  <main class="layout">
+    <section class="hero card">
+      <h1>在这里分享经验、提问和结识同好</h1>
+      <p>一个更像“社区”的主页：有人发帖、有人回复、有人组织活动。</p>
+      <div class="hero-stats">
+        <div><strong id="memberCount">0</strong><span>成员</span></div>
+        <div><strong id="postCount">0</strong><span>帖子</span></div>
+        <div><strong id="todayCount">0</strong><span>今日新帖</span></div>
       </div>
-      <img src="images/ev0logo.png" class="logo">
-    </div>
-    <div class="body">
-      <div class="face-one">
-        <div class="touchpad">
-        </div>
-        <div class="keyboard">
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key space"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-          <div class="key"></div>
-		  <div class="key"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-          <div class="key f"></div>
-        </div>
+    </section>
+
+    <section class="composer card" id="feed">
+      <h2>发布动态</h2>
+      <form id="postForm">
+        <input id="authorInput" type="text" maxlength="20" placeholder="你的昵称" required />
+        <input id="titleInput" type="text" maxlength="60" placeholder="标题" required />
+        <textarea id="contentInput" rows="4" maxlength="300" placeholder="分享你的想法、问题或项目进展..." required></textarea>
+        <button type="submit" class="btn-primary">发布帖子</button>
+      </form>
+    </section>
+
+    <section class="feed card">
+      <div class="feed-header">
+        <h2>社区动态</h2>
+        <select id="sortSelect" aria-label="动态排序">
+          <option value="latest">最新发布</option>
+          <option value="hot">最热互动</option>
+        </select>
       </div>
-      <div class="pad one"></div>
-      <div class="pad two"></div>
-      <div class="pad three"></div>
-      <div class="pad four"></div>
-    </div>
-  </div>
-  <div class="shadow"></div>
-</div>
-</div>
+      <div id="postList" class="post-list"></div>
+    </section>
 
-<!--居中内容-->
-<div class="r_content">	
-	<div class="con p_r flex">
-	 <!--你的名字-->   
-	<div class="name flex flex-align-center flex-pack-center OPPOSans-M p_r" id="one_part">
-	Z
-	<div class="tips te_c OPPOSans-B transition"><span class="p_r c1">455px</span></div>
-	</div>
-	
-	<!--小部件-GIF-->
-	<a href="http://www.ev0lve.xyz" class="flex flex-align-center flex-pack-center vr"><img src="images/ev0logo.png" w="115" h="115" ></a>
-	
-	<a href="https://unmatched.gg/" class="flex flex-align-center flex-pack-center web"><img src="images/logo.png" w="55" h="55"></a>
-	<a href="https://unmatched.gg/" class="flex flex-align-center flex-pack-center vr"><img src="images/ev0logo.png" w="115" h="115"></a>
-	</div>
-	
-	<!--个人定位-->
-    <div class="p_r flex con1">
-	<div class="txt_box p_r">
-	<div class="txt_con p_r flex">
-	<div class="ui flex flex-align-center flex-pack-center p_r OPPOSans-M flex-1" id="two_part">
-     real sadly
-	<div class="tips transition te_c OPPOSans-B transition flex flex-align-center flex-pack-center">
-	<span class="p_r">125px</span>
-	</div>
-	</div>
-	
-	<!--小部件-音乐-->
-    <div class="wx flex flex-align-center flex-pack-center p_r" id="three_part">
-    <audio src="test.mp3" controls="controls" preload id="music1" hidden>
-    </audio>
-    <span class="holder" id="bf" onclick="bf();">Music</span>
-    <div class="tips te_c OPPOSans-B transition">
-	<span class="p_r c2">70px</span>
-	</div>
-	</div>
-	</div>
-	
-	<!--个人简介-->
-	<div class="text OPPOSans-M p_r transition" id="four_part">
-	<span class="p_r di_in">2022年，冬 答应我会在一起很久</span>
-    <br>
-	<samp class="p_r di_in"> my life is shit</samp>
-	</div>
-	</div>
-	
-	<!--个人头像-->
-	<div class="pic flex flex-align-center flex-pack-center " id="five_part">
-	    <img src="images/PEBIX7ME5KZF44CREQ5F3OJ.gif" >
-	</div>
-	                          <!--触发器-->
+    <aside class="sidebar">
+      <section class="card" id="topics">
+        <h3>热门话题</h3>
+        <ul id="topicList" class="topic-list"></ul>
+      </section>
+      <section class="card" id="events">
+        <h3>社区活动</h3>
+        <ul class="event-list">
+          <li><strong>周三问答夜</strong><span>20:00 · 在线语音房</span></li>
+          <li><strong>开源项目结对</strong><span>周末 · 协作冲刺</span></li>
+          <li><strong>新人欢迎会</strong><span>每月 1 日 · 社群直播</span></li>
+        </ul>
+      </section>
+    </aside>
+  </main>
 
-<!--右侧内容-->
-<div class="works p_r OPPOSans-M"> 
-	<!-- w = 510 h= 250-->
-	<iframe width="510" height="251" src="https://www.youtube.com/embed/h3EJICKwITw" title="Juice WRLD" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<div class="txt">	
+  <template id="postTemplate">
+    <article class="post-item">
+      <header>
+        <div>
+          <h4 class="post-title"></h4>
+          <p class="post-meta"></p>
+        </div>
+        <span class="post-replies"></span>
+      </header>
+      <p class="post-content"></p>
+      <form class="reply-form">
+        <input type="text" maxlength="80" placeholder="写下你的回复，按回车发送" required />
+      </form>
+      <ul class="reply-list"></ul>
+    </article>
+  </template>
 
-
-</div>
-
-</div>
-</div>
-
-<!--下方内容-->
-<div class="p_r tool_content flex flex-align-center">
-<div class="sns flex ">
-<div class="flex-center">
-<!--小部件-微信-->
-<a>1</a>
-<!--小部件-邮箱-->                          
-
-<!--小部件-其他-->
-
-</div>
-</div>
-<div class="text OPPOSans-M">答应我会幸福<br>
-<p>see you fuck shit </p>
-</div>
-</div>
-</div>
-</div>
-
-
-
-<script src="js/jquery.SuperSlide.2.1.1.js"></script>
-<script>jQuery(".slideTxtBox").slide({});</script>
-<!-- 滑动效果 -->
-<script src="js/jquery.movebg.js"></script>
-<script>
-$(function(){
-	$(".link").movebg({width:125/*滑块的大小*/,extra:40/*额外反弹的距离*/,speed:300/*滑块移动的速度*/,rebound_speed:400/*滑块反弹的速度*/});
-})
-</script>
-<link rel="stylesheet" type="text/css" href="css/font.css"/>
-<script src="js/clipboard.min.js"></script>
-<script>//复制
-	var clipboard = new Clipboard('.copy');
-	clipboard.on('success', function(e) {
-		console.log(e);
-	});
-	clipboard.on('error', function(e) {
-		console.log(e);
-	});
-	$('#mail').click(function(){
-		$('#copyed').css('opacity',1)
-			setTimeout(function(){
-			$('#copyed').css('opacity',0)
-		},2000)
-	})
-	$('#one_part,#two_part,#three_part,#four_part,#five_part').hover(function(){
-		var that = $(this)
-		var target = that.attr('id').replace('_part','')
-		$('.focus .txt').hide()
-		$('#'+target).show()
-	},function(){
-		$('.focus .txt').hide()
-		$('#default').show()
-	})
-	$('#code').focus(function(){
-		$('#code').attr('placeholder','请输入提取码')
-		$('#code_error').hide()
-	})
-
-</script>
-<!--音乐-->
-<script>
-function rbf(){
- var audio = document.getElementById('music1'); 
- audio.currentTime = 0;
-}
-function bf(){
- var audio = document.getElementById('music1'); 
- if(audio!==null){             
-     alert(audio.paused);
-  if(audio.paused)                     {                 
-      audio.play('播放');  
-  }else{
-   audio.pause('暂停');
-  }
- } 
-}
-   
-</script>
-<script>
-try {
-	if (/Android|webOS|iPhone|iPod|BlackBerry/i.test(navigator.userAgent)) {
-
-	} else {
-
-			var canvas = document.querySelector('canvas'),
-				ctx = canvas.getContext('2d')
-				canvas.width = window.innerWidth;
-			canvas.height = window.innerHeight;
-			ctx.lineWidth = .3;
-			ctx.strokeStyle = (new Color(150)).style;
-
-			var mousePosition = {
-				x: 30 * canvas.width / 100,
-				y: 30 * canvas.height / 100
-			};
-
-			var dots = {
-				nb: 250,
-				distance: 100,
-				d_radius: 150,
-				array: []
-			};
-
-			function colorValue(min) {
-				return Math.floor(Math.random() * 255 + min);
-			}
-
-			function createColorStyle(r, g, b) {
-				return 'rgba(' + r + ',' + g + ',' + b + ', 0.8)';
-			}
-
-			function mixComponents(comp1, weight1, comp2, weight2) {
-				return (comp1 * weight1 + comp2 * weight2) / (weight1 + weight2);
-			}
-
-			function averageColorStyles(dot1, dot2) {
-				var color1 = dot1.color,
-					color2 = dot2.color;
-
-				var r = mixComponents(color1.r, dot1.radius, color2.r, dot2.radius),
-					g = mixComponents(color1.g, dot1.radius, color2.g, dot2.radius),
-					b = mixComponents(color1.b, dot1.radius, color2.b, dot2.radius);
-				return createColorStyle(Math.floor(r), Math.floor(g), Math.floor(b));
-			}
-
-			function Color(min) {
-				min = min || 0;
-				this.r = colorValue(min);
-				this.g = colorValue(min);
-				this.b = colorValue(min);
-				this.style = createColorStyle(this.r, this.g, this.b);
-			}
-
-			function Dot() {
-				this.x = Math.random() * canvas.width;
-				this.y = Math.random() * canvas.height;
-
-				this.vx = -.5 + Math.random();
-				this.vy = -.5 + Math.random();
-
-				this.radius = Math.random() * 2;
-
-				this.color = new Color();
-				console.log(this);
-			}
-
-			Dot.prototype = {
-				draw: function() {
-					ctx.beginPath();
-					ctx.fillStyle = this.color.style;
-					ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2, false);
-					ctx.fill();
-				}
-			};
-
-			function createDots() {
-				for (i = 0; i < dots.nb; i++) {
-					dots.array.push(new Dot());
-				}
-			}
-
-			function moveDots() {
-				for (i = 0; i < dots.nb; i++) {
-
-					var dot = dots.array[i];
-
-					if (dot.y < 0 || dot.y > canvas.height) {
-						dot.vx = dot.vx;
-						dot.vy = -dot.vy;
-					} else if (dot.x < 0 || dot.x > canvas.width) {
-						dot.vx = -dot.vx;
-						dot.vy = dot.vy;
-					}
-					dot.x += dot.vx;
-					dot.y += dot.vy;
-				}
-			}
-
-			function connectDots() {
-				for (i = 0; i < dots.nb; i++) {
-					for (j = 0; j < dots.nb; j++) {
-						i_dot = dots.array[i];
-						j_dot = dots.array[j];
-
-						if ((i_dot.x - j_dot.x) < dots.distance && (i_dot.y - j_dot.y) < dots.distance && (i_dot.x - j_dot.x) > -dots.distance && (i_dot.y - j_dot.y) > -dots.distance) {
-							if ((i_dot.x - mousePosition.x) < dots.d_radius && (i_dot.y - mousePosition.y) < dots.d_radius && (i_dot.x - mousePosition.x) > -dots.d_radius && (i_dot.y - mousePosition.y) > -dots.d_radius) {
-								ctx.beginPath();
-								ctx.strokeStyle = averageColorStyles(i_dot, j_dot);
-								ctx.moveTo(i_dot.x, i_dot.y);
-								ctx.lineTo(j_dot.x, j_dot.y);
-								ctx.stroke();
-								ctx.closePath();
-							}
-						}
-					}
-				}
-			}
-
-			function drawDots() {
-				for (i = 0; i < dots.nb; i++) {
-					var dot = dots.array[i];
-					dot.draw();
-				}
-			}
-
-			function animateDots() {
-				ctx.clearRect(0, 0, canvas.width, canvas.height);
-				moveDots();
-				//connectDots();
-				drawDots();
-
-				requestAnimationFrame(animateDots);
-			}
-
-
-			createDots();
-			requestAnimationFrame(animateDots);
-
-	}
-} catch (e) {}
-</script>
+  <script src="js/community.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <div class="background-glow"></div>
+
   <header class="topbar">
     <div class="logo">星火社区</div>
     <nav>
@@ -20,42 +21,45 @@
   </header>
 
   <main class="layout">
-    <section class="hero card">
-      <h1>在这里分享经验、提问和结识同好</h1>
-      <p>一个更像“社区”的主页：有人发帖、有人回复、有人组织活动。</p>
-      <div class="hero-stats">
-        <div><strong id="memberCount">0</strong><span>成员</span></div>
-        <div><strong id="postCount">0</strong><span>帖子</span></div>
-        <div><strong id="todayCount">0</strong><span>今日新帖</span></div>
-      </div>
-    </section>
+    <div class="main-column">
+      <section class="hero card">
+        <h1>在这里分享经验、提问和结识同好</h1>
+        <p>一个更像“社区”的主页：有人发帖、有人回复、有人组织活动。</p>
+        <div class="hero-stats">
+          <div><strong id="memberCount">0</strong><span>成员</span></div>
+          <div><strong id="postCount">0</strong><span>帖子</span></div>
+          <div><strong id="todayCount">0</strong><span>今日新帖</span></div>
+        </div>
+      </section>
 
-    <section class="composer card" id="feed">
-      <h2>发布动态</h2>
-      <form id="postForm">
-        <input id="authorInput" type="text" maxlength="20" placeholder="你的昵称" required />
-        <input id="titleInput" type="text" maxlength="60" placeholder="标题" required />
-        <textarea id="contentInput" rows="4" maxlength="300" placeholder="分享你的想法、问题或项目进展..." required></textarea>
-        <button type="submit" class="btn-primary">发布帖子</button>
-      </form>
-    </section>
+      <section class="composer card" id="feed">
+        <h2>发布动态</h2>
+        <form id="postForm">
+          <input id="authorInput" type="text" maxlength="20" placeholder="你的昵称" required />
+          <input id="titleInput" type="text" maxlength="60" placeholder="标题" required />
+          <textarea id="contentInput" rows="4" maxlength="300" placeholder="分享你的想法、问题或项目进展..." required></textarea>
+          <button type="submit" class="btn-primary">发布帖子</button>
+        </form>
+      </section>
 
-    <section class="feed card">
-      <div class="feed-header">
-        <h2>社区动态</h2>
-        <select id="sortSelect" aria-label="动态排序">
-          <option value="latest">最新发布</option>
-          <option value="hot">最热互动</option>
-        </select>
-      </div>
-      <div id="postList" class="post-list"></div>
-    </section>
+      <section class="feed card">
+        <div class="feed-header">
+          <h2>社区动态</h2>
+          <select id="sortSelect" aria-label="动态排序">
+            <option value="latest">最新发布</option>
+            <option value="hot">最热互动</option>
+          </select>
+        </div>
+        <div id="postList" class="post-list"></div>
+      </section>
+    </div>
 
     <aside class="sidebar">
       <section class="card" id="topics">
         <h3>热门话题</h3>
         <ul id="topicList" class="topic-list"></ul>
       </section>
+
       <section class="card" id="events">
         <h3>社区活动</h3>
         <ul class="event-list">

--- a/index.html
+++ b/index.html
@@ -42,6 +42,13 @@
         </form>
       </section>
 
+
+    <div class="quick-links card">
+      <h2>功能入口</h2>
+      <p><a href="login/index.html">登录模块</a> · <a href="game/index.html">游戏模块（单页面）</a></p>
+      <p>后端请运行 FastAPI：<code>uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000</code></p>
+    </div>
+
       <section class="feed card">
         <div class="feed-header">
           <h2>社区动态</h2>

--- a/js/community.js
+++ b/js/community.js
@@ -1,0 +1,159 @@
+const STORAGE_KEY = "spark-community-posts";
+const MEMBER_COUNT = 1842;
+
+const defaultPosts = [
+  {
+    id: crypto.randomUUID(),
+    author: "阿泽",
+    title: "大家如何组织线上读书会？",
+    content: "我们准备每周一次 45 分钟，想听听你们的流程建议。",
+    createdAt: new Date().toISOString(),
+    replies: ["建议固定主持人和轮值记录员", "先收集问题再共读会更高效"]
+  },
+  {
+    id: crypto.randomUUID(),
+    author: "Mia",
+    title: "开源协作招募前端同学",
+    content: "正在做一个社区工具面板，欢迎来一起打磨交互和可访问性。",
+    createdAt: new Date(Date.now() - 36e5).toISOString(),
+    replies: ["有仓库地址吗？", "可否支持移动端优先？", "我想参与测试"]
+  }
+];
+
+const api = {
+  async listPosts() {
+    return this._read();
+  },
+  async createPost(data) {
+    const posts = this._read();
+    posts.unshift({
+      id: crypto.randomUUID(),
+      ...data,
+      createdAt: new Date().toISOString(),
+      replies: []
+    });
+    this._write(posts);
+    return posts;
+  },
+  async createReply(postId, text) {
+    const posts = this._read();
+    const target = posts.find((post) => post.id === postId);
+    if (!target) return posts;
+    target.replies.push(text);
+    this._write(posts);
+    return posts;
+  },
+  _read() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(defaultPosts));
+      return [...defaultPosts];
+    }
+    return JSON.parse(raw);
+  },
+  _write(posts) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+  }
+};
+
+const postForm = document.querySelector("#postForm");
+const postList = document.querySelector("#postList");
+const sortSelect = document.querySelector("#sortSelect");
+const template = document.querySelector("#postTemplate");
+const topicList = document.querySelector("#topicList");
+const memberCount = document.querySelector("#memberCount");
+const postCount = document.querySelector("#postCount");
+const todayCount = document.querySelector("#todayCount");
+
+function formatTime(iso) {
+  const date = new Date(iso);
+  return `${date.getMonth() + 1}/${date.getDate()} ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+function sortPosts(posts) {
+  if (sortSelect.value === "hot") {
+    return [...posts].sort((a, b) => b.replies.length - a.replies.length);
+  }
+  return [...posts].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+}
+
+function renderTopics(posts) {
+  const counter = new Map();
+  posts.forEach((post) => {
+    post.title.split(/\s+/).forEach((word) => {
+      if (word.length < 2) return;
+      counter.set(word, (counter.get(word) || 0) + 1);
+    });
+  });
+
+  const topics = [...counter.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([word, count]) => `<li>#${word} · ${count} 次讨论</li>`)
+    .join("");
+
+  topicList.innerHTML = topics || "<li>#新人报到 · 1 次讨论</li>";
+}
+
+function renderStats(posts) {
+  memberCount.textContent = MEMBER_COUNT.toLocaleString("zh-CN");
+  postCount.textContent = posts.length.toString();
+  const today = new Date().toDateString();
+  const todayPosts = posts.filter((post) => new Date(post.createdAt).toDateString() === today).length;
+  todayCount.textContent = String(todayPosts);
+}
+
+function renderPosts(posts) {
+  postList.innerHTML = "";
+  sortPosts(posts).forEach((post) => {
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.querySelector(".post-title").textContent = post.title;
+    node.querySelector(".post-meta").textContent = `${post.author} · ${formatTime(post.createdAt)}`;
+    node.querySelector(".post-content").textContent = post.content;
+    node.querySelector(".post-replies").textContent = `${post.replies.length} 条回复`;
+
+    const replyList = node.querySelector(".reply-list");
+    replyList.innerHTML = post.replies.map((reply) => `<li>${reply}</li>`).join("");
+
+    const replyForm = node.querySelector(".reply-form");
+    replyForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const input = replyForm.querySelector("input");
+      const value = input.value.trim();
+      if (!value) return;
+      const updated = await api.createReply(post.id, value);
+      input.value = "";
+      render(updated);
+    });
+
+    postList.appendChild(node);
+  });
+}
+
+async function render(postsInput) {
+  const posts = postsInput || (await api.listPosts());
+  renderStats(posts);
+  renderTopics(posts);
+  renderPosts(posts);
+}
+
+postForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const data = {
+    author: document.querySelector("#authorInput").value.trim(),
+    title: document.querySelector("#titleInput").value.trim(),
+    content: document.querySelector("#contentInput").value.trim()
+  };
+  if (!data.author || !data.title || !data.content) return;
+
+  const updated = await api.createPost(data);
+  postForm.reset();
+  render(updated);
+});
+
+sortSelect.addEventListener("change", () => render());
+document.querySelector("#joinBtn").addEventListener("click", () => {
+  alert("欢迎加入星火社区！先从发布第一条动态开始吧～");
+});
+
+render();

--- a/login/app.js
+++ b/login/app.js
@@ -1,0 +1,67 @@
+const TOKEN_KEY = "spark_token";
+const USER_KEY = "spark_user";
+
+const apiBaseInput = document.querySelector("#apiBase");
+const usernameInput = document.querySelector("#username");
+const passwordInput = document.querySelector("#password");
+const statusEl = document.querySelector("#status");
+const tokenView = document.querySelector("#tokenView");
+
+function showStatus(text, ok = true) {
+  statusEl.textContent = text;
+  statusEl.style.color = ok ? "#7af7d5" : "#ff8f8f";
+}
+
+function saveSession(data) {
+  localStorage.setItem(TOKEN_KEY, data.token);
+  localStorage.setItem(USER_KEY, data.username);
+  tokenView.textContent = JSON.stringify(data, null, 2);
+}
+
+async function request(path, payload) {
+  const base = apiBaseInput.value.trim().replace(/\/$/, "");
+  const res = await fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.detail || "请求失败");
+  }
+  return data;
+}
+
+async function handleRegister() {
+  try {
+    await request("/api/auth/register", {
+      username: usernameInput.value.trim(),
+      password: passwordInput.value
+    });
+    showStatus("注册成功，请继续登录");
+  } catch (error) {
+    showStatus(error.message, false);
+  }
+}
+
+async function handleLogin() {
+  try {
+    const data = await request("/api/auth/login", {
+      username: usernameInput.value.trim(),
+      password: passwordInput.value
+    });
+    saveSession(data);
+    showStatus("登录成功，已保存到 localStorage");
+  } catch (error) {
+    showStatus(error.message, false);
+  }
+}
+
+document.querySelector("#registerBtn").addEventListener("click", handleRegister);
+document.querySelector("#loginBtn").addEventListener("click", handleLogin);
+
+const token = localStorage.getItem(TOKEN_KEY);
+const username = localStorage.getItem(USER_KEY);
+if (token && username) {
+  tokenView.textContent = JSON.stringify({ token, username }, null, 2);
+}

--- a/login/index.html
+++ b/login/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>登录模块 - 星火社区</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="card">
+    <h1>登录 / 注册</h1>
+    <p class="muted">后端：FastAPI（默认地址 `http://127.0.0.1:8000`）</p>
+
+    <label>后端地址</label>
+    <input id="apiBase" value="http://127.0.0.1:8000" />
+
+    <label>用户名</label>
+    <input id="username" maxlength="20" placeholder="至少 3 位" />
+
+    <label>密码</label>
+    <input id="password" type="password" maxlength="64" placeholder="至少 6 位" />
+
+    <div class="actions">
+      <button id="registerBtn">注册</button>
+      <button id="loginBtn">登录</button>
+    </div>
+
+    <p id="status" class="status"></p>
+
+    <section class="result">
+      <h2>当前登录态</h2>
+      <pre id="tokenView">尚未登录</pre>
+      <a href="../game/index.html">进入游戏模块 →</a>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/login/style.css
+++ b/login/style.css
@@ -1,0 +1,50 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: #0d1328;
+  color: #e8f0ff;
+  display: grid;
+  place-items: center;
+}
+
+.card {
+  width: min(460px, 92vw);
+  background: #151e3f;
+  border: 1px solid #324a8b;
+  border-radius: 14px;
+  padding: 24px;
+}
+
+h1, h2, p { margin: 0 0 10px; }
+label { display:block; margin: 10px 0 6px; }
+input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid #4c67b2;
+  background: #0d142d;
+  color: #fff;
+}
+.actions { display: flex; gap: 10px; margin-top: 16px; }
+button {
+  flex: 1;
+  padding: 10px;
+  border: none;
+  border-radius: 10px;
+  background: linear-gradient(120deg, #6ca8ff, #7a84ff);
+  color: #fff;
+  cursor: pointer;
+}
+.muted { color: #9fb1d8; }
+.status { min-height: 22px; margin-top: 12px; color: #7af7d5; }
+.result { margin-top: 18px; }
+pre {
+  white-space: pre-wrap;
+  background: #0a1024;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid #324a8b;
+}
+a { color: #7af7d5; }


### PR DESCRIPTION
### Motivation
- 将原先的个人展示主页改造成更像“社区”的首页，提供发帖、回复和话题聚合等交互，增强前后端（前端“轻后端”）能力以支持社区场景。

### Description
- 将 `index.html` 重构为社区布局，新增顶部导航、社区统计、发帖区、动态流、热门话题和活动侧栏（见 `index.html`）。
- 重写 `css/style.css`，引入深色卡片式风格与响应式规则以改善视觉和可读性（见 `css/style.css`）。
- 新增 `js/community.js`，实现基于 `localStorage` 的帖子持久化与交互逻辑，包括发帖、回复、按最新/最热排序、成员/帖子/今日统计与自动提取热门话题（见 `js/community.js`）。
- 对老的展示/动画/多余资源移除或简化，使页面结构更聚焦社区功能并减小样式体积。

### Testing
- 在本地对脚本进行语法检查：运行 `node --check js/community.js`，结果通过（成功）。
- 启动静态服务器并校验页面可访问性：运行 `python -m http.server 4173 --directory /workspace/rosebot1337.github.io` 后使用 `curl -I http://127.0.0.1:4173/index.html` 获取到 `HTTP/1.0 200 OK`，访问验证通过。
- 在浏览器自动化尝试生成截图时使用 Playwright，但受限环境中 Chromium 进程在启动后崩溃（SIGSEGV），未能产出截图（失败）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a69299d0b88330a5b8cd5f262ad984)